### PR TITLE
背景グラデーションを再構成

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,8 +25,9 @@ export default function RootLayout({
   return (
     <html lang="en" className="h-full">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gradient-to-bl from-[#FBAFB7] via-[#E7D1D9] to-[#A8EAEF]`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased relative`}
       >
+        <div className="absolute top-0 left-0 -z-1 w-full h-full bg-linear-to-bl from-[#FBAFB7] via-[#E7D1D9] to-[#A8EAEF]" />
         {children}
       </body>
     </html>


### PR DESCRIPTION
背景グラデーションがスクリーンサイズを超える際に境界線を生み出していたの修正。
ただし、これは一時的な対処でこのグラデーションは本来、背景に固定されてスクロールでは動かないことが望ましい可能性があるので、追加の修正が必要かもしれません。